### PR TITLE
MCCordovaPlugin.js fixed functions reference

### DIFF
--- a/www/MCCordovaPlugin.js
+++ b/www/MCCordovaPlugin.js
@@ -3,11 +3,11 @@ var exec = require('cordova/exec');
 module.exports = {
 
   //Logging
-  enableVerboseLogging(successCallback, errorCallback){
+  enableVerboseLogging: function(successCallback, errorCallback){
     cordova.exec(successCallback, errorCallback, "MCCordovaPlugin", "enableVerboseLogging");
   },
 
-  disableVerboseLogging(successCallback, errorCallback){
+  disableVerboseLogging: function(successCallback, errorCallback){
     cordova.exec(successCallback, errorCallback, "MCCordovaPlugin", "disableVerboseLogging");
   },
 


### PR DESCRIPTION
If enableVerboseLogging and disableVerboseLogging are not references of functions the code crash