### PR TITLE
Register notifications to IOS with a function

### DIFF
--- a/src/android/MCCordovaPluginApplication.java
+++ b/src/android/MCCordovaPluginApplication.java
@@ -13,6 +13,8 @@ import com.salesforce.marketingcloud.registration.RegistrationManager;
 import java.util.Set;
 import java.util.TreeSet;
 
+import nl.matise.expeditiewadden.R;
+
 public class MCCordovaPluginApplication extends Application {
 
     private static final String TAG = "~#MCSdkCordovaApp";

--- a/src/android/MCCordovaPluginApplication.java
+++ b/src/android/MCCordovaPluginApplication.java
@@ -13,8 +13,6 @@ import com.salesforce.marketingcloud.registration.RegistrationManager;
 import java.util.Set;
 import java.util.TreeSet;
 
-import nl.matise.expeditiewadden.R;
-
 public class MCCordovaPluginApplication extends Application {
 
     private static final String TAG = "~#MCSdkCordovaApp";

--- a/src/ios/AppDelegate+MCCordovaPlugin.m
+++ b/src/ios/AppDelegate+MCCordovaPlugin.m
@@ -55,16 +55,16 @@ static NSString * const CURRENT_CORDOVA_VERSION_NAME = @"MC_Cordova_v1.0.2";
             useAnalytics = YES;
         }
     }
-             
+
 	// configure and set initial settings of the JB4ASDK
-	successful = [[ETPush pushManager] 
-		configureSDKWithAppID:[ETSettings objectForKey:@"APPID"] 
-		andAccessToken:[ETSettings objectForKey:@"ACCESSTOKEN"] 
+	successful = [[ETPush pushManager]
+		configureSDKWithAppID:[ETSettings objectForKey:@"APPID"]
+		andAccessToken:[ETSettings objectForKey:@"ACCESSTOKEN"]
 		withAnalytics:useAnalytics
-		andLocationServices:NO 
-		andProximityServices:NO 
-		andCloudPages:NO 
-		withPIAnalytics:NO 
+		andLocationServices:NO
+		andProximityServices:NO
+		andCloudPages:NO
+		withPIAnalytics:NO
 		error:&error ];
 
 	//
@@ -81,16 +81,6 @@ static NSString * const CURRENT_CORDOVA_VERSION_NAME = @"MC_Cordova_v1.0.2";
 			otherButtonTitles:nil] show];
 		});
 	} else {
-		// register for push notifications - enable all notification types, no categories
-		UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:
-																						UIUserNotificationTypeBadge |
-																						UIUserNotificationTypeSound |
-																						UIUserNotificationTypeAlert
-																						categories:nil];
-
-		[[ETPush pushManager] registerUserNotificationSettings:settings];
-		[[ETPush pushManager] registerForRemoteNotifications];
-        
         //MC_Cordova-vX.Y.Z
         //Replace any older tags
         NSSet *tagsSet = [[ETPush pushManager] getTags];
@@ -102,7 +92,7 @@ static NSString * const CURRENT_CORDOVA_VERSION_NAME = @"MC_Cordova_v1.0.2";
                 [[ETPush pushManager] removeTag:tag]; //remove old tag version
             }
         }
-        
+
         [[ETPush pushManager] addTag:CURRENT_CORDOVA_VERSION_NAME]; //add new tag version
 	}
 

--- a/src/ios/MCCordovaPlugin.h
+++ b/src/ios/MCCordovaPlugin.h
@@ -8,6 +8,7 @@
 - (void)enableVerboseLogging:(CDVInvokedUrlCommand*)command;
 - (void)disableVerboseLogging:(CDVInvokedUrlCommand*)command;
 
+- (void)registerPush:(CDVInvokedUrlCommand*)command;
 - (void)getSystemToken:(CDVInvokedUrlCommand*)command;
 - (void)isPushEnabled:(CDVInvokedUrlCommand*)command;
 - (void)enablePush:(CDVInvokedUrlCommand*)command;

--- a/src/ios/MCCordovaPlugin.m
+++ b/src/ios/MCCordovaPlugin.m
@@ -21,6 +21,18 @@
 
 #pragma mark - Push
     
+- (void)registerPush:(CDVInvokedUrlCommand*)command {
+    // register for push notifications - enable all notification types, no categories
+    UIUserNotificationSettings *settings = [UIUserNotificationSettings settingsForTypes:
+                                            UIUserNotificationTypeBadge |
+                                            UIUserNotificationTypeSound |
+                                            UIUserNotificationTypeAlert
+                                            categories:nil];
+
+    [[ETPush pushManager] registerUserNotificationSettings:settings];
+    [[ETPush pushManager] registerForRemoteNotifications];
+}
+
 - (void)isPushEnabled:(CDVInvokedUrlCommand*)command {
     BOOL pushEnabled = [ETPush isPushEnabled];
     CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsBool:pushEnabled];

--- a/www/MCCordovaPlugin.js
+++ b/www/MCCordovaPlugin.js
@@ -12,6 +12,10 @@ module.exports = {
   },
 
   //push
+  registerPush: function(successCallback, errorCallback) {
+	cordova.exec(successCallback, errorCallback, "MCCordovaPlugin", "registerPush", []);
+  },
+
   enablePush: function(successCallback, errorCallback) {
       cordova.exec(successCallback, errorCallback, "MCCordovaPlugin", "enablePush", []);
   },


### PR DESCRIPTION
So I needed control over when the user gets the notification to allow push notifications and I came up with a solution.
I placed the `[[ETPush pushManager] registerForRemoteNotifications];` in its own function, so it can (and should) be called on its own from your app.