### PR TITLE
iOS/iPadOS tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Follow [these instructions](./ios_push.md) to enable push for iOS.
 * [MCCordovaPlugin](#module_MCCordovaPlugin)
     * _static_
         * [.isPushEnabled(successCallback, [errorCallback])](#module_MCCordovaPlugin.isPushEnabled)
+        * [.requestPushPermission(successCallback, [errorCallback])](#module_MCCordovaPlugin.requestPushPermission)
+        * [.getPushNotificationSettings(successCallback, [errorCallback])](#module_MCCordovaPlugin.getPushNotificationSettings)
         * [.enablePush([successCallback], [errorCallback])](#module_MCCordovaPlugin.enablePush)
         * [.disablePush([successCallback], [errorCallback])](#module_MCCordovaPlugin.disablePush)
         * [.getSystemToken(successCallback, [errorCallback])](#module_MCCordovaPlugin.getSystemToken)
@@ -106,6 +108,41 @@ SDK.
 | --- | --- | --- |
 | successCallback | <code>function</code> |  |
 | successCallback.enabled | <code>boolean</code> | Whether push is enabled. |
+| [errorCallback] | <code>function</code> |  |
+
+<a name="module_MCCordovaPlugin.requestPushPermission"></a>
+
+### MCCordovaPlugin.requestPushPermission(successCallback, [errorCallback])
+Requests iOS/iPadOS to ask the user to enable push notifications for
+the App. The user will be prompted only once.
+
+**Kind**: static method of <code>[MCCordovaPlugin](#module_MCCordovaPlugin)</code>  
+**See**
+
+- [iOS Docs](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorizationwithoptions)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| successCallback | <code>function</code> |  |
+| successCallback.granted | <code>boolean</code> | Whether permission to receive push notifications was granted. |
+| [errorCallback] | <code>function</code> |  |
+
+<a name="module_MCCordovaPlugin.getPushNotificationSettings"></a>
+
+### MCCordovaPlugin.getPushNotificationSettings(successCallback, [errorCallback])
+Gets the notification settings for this app. Applies only to iOS/iPadOS.
+
+**Kind**: static method of <code>[MCCordovaPlugin](#module_MCCordovaPlugin)</code>  
+**See**
+
+- [iOS Docs](https://developer.apple.com/documentation/usernotifications/unauthorizationstatus)
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| successCallback | <code>function</code> |  |
+| successCallback.status | <code>string</code> | One of the following values: 'not-determined', 'denied', 'authorized', 'provisional'. |
 | [errorCallback] | <code>function</code> |  |
 
 <a name="module_MCCordovaPlugin.enablePush"></a>

--- a/www/MCCordovaPlugin.js
+++ b/www/MCCordovaPlugin.js
@@ -105,6 +105,31 @@ var MCCordovaPlugin = {
     },
 
     /**
+     * Requests iOS/iPadOS to ask the user to enable push notifications for the App. The user will be prompted only once.
+     * @param  {function(granted)} [successCallback]
+     * @param  {boolean} successCallback.granted - Whether permission to receive push notifications was granted.
+     * @param  {function} [errorCallback]
+     * @remark On iOS 9 or older this method will always report success regardless of the user's response to the prompt.
+     * @see  {@link https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorizationwithoptions:|iOS Docs}
+     */
+    requestPushPermission: function(successCallback = undefined, errorCallback = undefined) {
+        argsCheck.checkArgs('FF', `${PLUGIN_NAME}.requestPushPermission`, arguments);
+        _exec(successCallback, errorCallback, 'requestPushPermission');
+    },
+               
+    /**
+     * Gets the notification settings for this app. Applies only to iOS/iPadOS
+     * @param  {function(status)} [successCallback]
+     * @param  {string} successCallback.status - One of the following values: 'not-determined', 'denied', 'authorized', 'provisional'
+     * @param  {function} [errorCallback]
+     * @see  {@link https://developer.apple.com/documentation/usernotifications/unauthorizationstatus:|iOS Docs}
+     */
+    getPushNotificationSettings: function(successCallback = undefined, errorCallback = undefined) {
+        argsCheck.checkArgs('FF', `${PLUGIN_NAME}.getNotificationSettings`, arguments);
+        _exec(successCallback, errorCallback, 'getNotificationSettings');
+    },
+
+    /**
      * Returns the token used by the Marketing Cloud to send push messages to
      * the device.
      * @param  {function(token)} successCallback

--- a/www/MCCordovaPlugin.js
+++ b/www/MCCordovaPlugin.js
@@ -118,9 +118,9 @@ var MCCordovaPlugin = {
     },
                
     /**
-     * Gets the notification settings for this app. Applies only to iOS/iPadOS
+     * Gets the notification settings for this app. Applies only to iOS/iPadOS.
      * @param  {function(status)} [successCallback]
-     * @param  {string} successCallback.status - One of the following values: 'not-determined', 'denied', 'authorized', 'provisional'
+     * @param  {string} successCallback.status - One of the following values: 'not-determined', 'denied', 'authorized', 'provisional'.
      * @param  {function} [errorCallback]
      * @see  {@link https://developer.apple.com/documentation/usernotifications/unauthorizationstatus:|iOS Docs}
      */


### PR DESCRIPTION
* Avoid asking for permission for push notifications when the plugin is initialised, that is a poor user experience;
* Added method for asking for permission;
* Added method for knowing the permission status;