### PR TITLE
Fix delayRegistrationUntilContactKeyIsSet

### DIFF
--- a/src/ios/MCCordovaPlugin.m
+++ b/src/ios/MCCordovaPlugin.m
@@ -131,9 +131,9 @@ const int LOG_LENGTH = 800;
         BOOL analytics = [pluginSettings[@"com.salesforce.marketingcloud.analytics"] boolValue];
         [configBuilder setAnalyticsEnabled:analytics];
         
-        BOOL delayRegistrationUntilContactKeyIsSet = [pluginSettings
-                                                      [@"com.salesforce.marketingcloud.delay_registration_until_contact_key_is_set"]
-                                                      boolValue];
+        NSNumber *delayRegistrationUntilContactKeyIsSet = [NSNumber numberWithBool:[
+         [pluginSettings[@"com.salesforce.marketingcloud.delay_registration_until_contact_key_is_set"] boolValue]]];
+
         [configBuilder
          setDelayRegistrationUntilContactKeyIsSet:delayRegistrationUntilContactKeyIsSet];
         

--- a/src/ios/MCCordovaPlugin.m
+++ b/src/ios/MCCordovaPlugin.m
@@ -131,11 +131,11 @@ const int LOG_LENGTH = 800;
         BOOL analytics = [pluginSettings[@"com.salesforce.marketingcloud.analytics"] boolValue];
         [configBuilder setAnalyticsEnabled:analytics];
         
-        NSNumber *delayRegistrationUntilContactKeyIsSet = [NSNumber numberWithBool:[
-         [pluginSettings[@"com.salesforce.marketingcloud.delay_registration_until_contact_key_is_set"] boolValue]]];
+        NSNumber *delayRegistrationUntilContactKeyIsSet =
+        [NSNumber numberWithBool:
+         [pluginSettings[@"com.salesforce.marketingcloud.delay_registration_until_contact_key_is_set"] boolValue]];
 
-        [configBuilder
-         setDelayRegistrationUntilContactKeyIsSet:delayRegistrationUntilContactKeyIsSet];
+        [configBuilder setDelayRegistrationUntilContactKeyIsSet:delayRegistrationUntilContactKeyIsSet];
         
         NSURL *tse =
         [NSURL URLWithString:pluginSettings


### PR DESCRIPTION
We have found it impossible to make the `salesforce.marketingcloud.delay_registration_until_contact_key_is_set` setting work from the settings file in iOS. As a result, we have resorted to forcefully setting it in a Swift file instead.

Upon inspecting the code, I suspect that the issue may be related to a type mismatch between Bool and NSNumber at the `setDelayRegistrationUntilContactKeyIsSet` method invocation.

I understand that this might be a long shot, as I have no experience with Objective-C, Cordova plugins, or Mac development, and I don't even have access to a Mac. Nonetheless, I wanted to share this observation.